### PR TITLE
fix #32 - dlopen wrapper with RTLD_DEEPBIND

### DIFF
--- a/libinit.c
+++ b/libinit.c
@@ -168,7 +168,7 @@ static int MUK_Alkaa(int * argc, char *** argv, int requested, int * provided)
     wrapname = pathname;
 #endif
 
-    int flags = RTLD_LAZY;
+    int flags = RTLD_LOCAL | RTLD_LAZY;
 #ifdef RTLD_DEEPBIND
 	flags |= RTLD_DEEPBIND;
 #endif

--- a/libinit.c
+++ b/libinit.c
@@ -168,7 +168,7 @@ static int MUK_Alkaa(int * argc, char *** argv, int requested, int * provided)
     wrapname = pathname;
 #endif
 
-    void * wrap_so_handle = dlopen(wrapname, RTLD_LAZY);
+    void * wrap_so_handle = dlopen(wrapname, RTLD_LAZY | RTLD_DEEPBIND);
     if (wrap_so_handle == NULL) {
         printf("dlopen of %s failed: %s\n", wrapname, dlerror() );
         abort();

--- a/libinit.c
+++ b/libinit.c
@@ -168,7 +168,11 @@ static int MUK_Alkaa(int * argc, char *** argv, int requested, int * provided)
     wrapname = pathname;
 #endif
 
-    void * wrap_so_handle = dlopen(wrapname, RTLD_LAZY | RTLD_DEEPBIND);
+    int flags = RTLD_LAZY;
+#ifdef RTLD_DEEPBIND
+	flags |= RTLD_DEEPBIND;
+#endif
+    void * wrap_so_handle = dlopen(wrapname, flags);
     if (wrap_so_handle == NULL) {
         printf("dlopen of %s failed: %s\n", wrapname, dlerror() );
         abort();


### PR DESCRIPTION
As discussed in https://github.com/jeffhammond/mukautuva/issues/32, this MR adds the `RTLD_DEEPBIND` flag to the `dlopen` call for the wrapper library.